### PR TITLE
Add newline to arguments check fail

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -164,7 +164,7 @@ int main(int argc, char *argv[]) {
 
     // check if number of arguments is correct
     if (argc <= 1 || strlen(argv[1]) <= 0) {
-        printf("\u001b[0mplease provide the filename as the first input argument");
+        printf("\u001b[0mplease provide the filename as the first input argument\n");
         fflush(stdout);
         return 0;
     }


### PR DESCRIPTION
There is no newline at the end, so the prompt goes into the same line.